### PR TITLE
Removed restriction on TARGET_TYPES (Release, Debug)

### DIFF
--- a/lib/fastlane/plugin/xamarin_build/actions/xamarin_build_action.rb
+++ b/lib/fastlane/plugin/xamarin_build/actions/xamarin_build_action.rb
@@ -40,7 +40,6 @@ module Fastlane
         ['punksta']
       end
 
-      TARGET_TYPES = %w(Release Debug).freeze
       PRINT_ALL = [true, false].freeze
 
       def self.available_options
@@ -65,10 +64,7 @@ module Fastlane
             key: :target,
             env_name: 'FL_XAMARIN_BUILD_TARGET',
             description: 'Target build type',
-            type: String,
-            verify_block: proc do |value|
-              UI.user_error!("Unsupported platform. Use one of #{TARGET_TYPES.join '\' '}".red) unless TARGET_TYPES.include? value
-            end
+            type: String
           ),
 
           FastlaneCore::ConfigItem.new(

--- a/lib/fastlane/plugin/xamarin_build/version.rb
+++ b/lib/fastlane/plugin/xamarin_build/version.rb
@@ -1,9 +1,5 @@
 module Fastlane
   module XamarinBuild
-    VERSION = "0.1.3"
+    VERSION = "0.2.1"
   end
 end
-
-
-
-


### PR DESCRIPTION
In most apps with an API, more than just these TARGET_TYPES exist, such
as Debug.Test, Debug.UAT, Debug.Production and similar for Release.

We probably shouldn't dictate what names users define for their build configurations