### PR TITLE
switched mdtool to use renamed vstool from Visual Studio for Mac

### DIFF
--- a/lib/fastlane/plugin/xamarin_build/actions/xamarin_build_action.rb
+++ b/lib/fastlane/plugin/xamarin_build/actions/xamarin_build_action.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     class XamarinBuildAction < Action
-      MDTOOL = '/Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool'.freeze
+      MDTOOL = '/Applications/Visual\ Studio.app/Contents/MacOS/vstool'.freeze
       XBUILD = '/Library/Frameworks/Mono.framework/Commands/xbuild'.freeze
 
       def self.run(params)


### PR DESCRIPTION
Xamarin Studio is being replaced by Visual Studio for Mac. VS for Mac has renamed the mdtool to vstool and therefore we need to change the path to the vstool.
I am not sure if this is the only place it has to be renamed (I am not too experienced in Ruby). Do you know if it has to be changed elsewhere? And if I can test this locally somehow? 